### PR TITLE
Add Volume Envelope preview to instrument editor

### DIFF
--- a/src/components/music/InstrumentDutyEditor.tsx
+++ b/src/components/music/InstrumentDutyEditor.tsx
@@ -7,6 +7,7 @@ import { FormDivider, FormField, FormRow } from "../ui/form/FormLayout";
 import { Select } from "../ui/form/Select";
 import { SliderField } from "../ui/form/SliderField";
 import { InstrumentLengthForm } from "./InstrumentLengthForm";
+import { VolumeEnvelopeForm as VolumeEnvelopeForm } from "./VolumeEnvelopeForm";
 
 const dutyOptions = [
   {
@@ -140,6 +141,13 @@ export const InstrumentDutyEditor = ({
           }}
         />
       </FormRow>
+
+      <VolumeEnvelopeForm
+        volume={instrument.initial_volume}
+        volume_sweep_change={instrument.volume_sweep_change}
+        length={instrument.length || 0}
+        onChange={onChangeField("volume_sweep_change" || "initial_volume" || "length")}
+      />
 
       <FormDivider />
 

--- a/src/components/music/InstrumentNoiseEditor.tsx
+++ b/src/components/music/InstrumentNoiseEditor.tsx
@@ -8,6 +8,7 @@ import { CheckboxField } from "../ui/form/CheckboxField";
 import { FormDivider, FormRow } from "../ui/form/FormLayout";
 import { SliderField } from "../ui/form/SliderField";
 import { InstrumentLengthForm } from "./InstrumentLengthForm";
+import { VolumeEnvelopeForm as VolumeEnvelopeForm } from "./VolumeEnvelopeForm";
 
 interface InstrumentNoiseEditorProps {
   id: string;
@@ -84,6 +85,13 @@ export const InstrumentNoiseEditor = ({
           }}
         />
       </FormRow>
+
+      <VolumeEnvelopeForm
+        volume={instrument.initial_volume}
+        volume_sweep_change={instrument.volume_sweep_change}
+        length={instrument.length || 0}
+        onChange={onChangeField("volume_sweep_change" || "initial_volume" || "length")}
+      />
 
       <FormDivider />
 

--- a/src/components/music/VolumeEnvelopeForm.tsx
+++ b/src/components/music/VolumeEnvelopeForm.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useRef } from "react";
+import { useSelector } from "react-redux";
+import { ValueType, ActionMeta } from "react-select";
+import { Select } from "../ui/form/Select";
+import l10n from "../../lib/helpers/l10n";
+import { RootState } from "../../store/configureStore";
+import { FormRow, FormField } from "../ui/form/FormLayout";
+
+interface VolumeEnvelopeFormProps {
+  volume: number,
+  volume_sweep_change: number,
+  length: number,
+  onChange: (value: ValueType<any>, actionMeta: ActionMeta<any>) => void;
+}
+
+export const VolumeEnvelopeForm = ({
+  volume,
+  volume_sweep_change,
+  length,
+  onChange
+}: VolumeEnvelopeFormProps) => {
+
+  const song = useSelector((state: RootState) =>
+    state.trackerDocument.present.song
+  );
+
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  useEffect(() => {
+    if (!song) {
+      return;
+    }
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+  
+    const drawWidth = canvas.width - 10;
+    const drawHeight = canvas.height - 10;
+    const ctx = canvas.getContext("2d");
+
+    const defaultColor = getComputedStyle(
+      document.documentElement
+    ).getPropertyValue("--highlight-color");
+
+    canvas.width = canvas.clientWidth;
+
+    if (ctx) {
+
+      const normalisedVolume = volume / 15;
+      const secLength = length ? length / 64 / 2 : 1;
+
+      ctx.strokeStyle = defaultColor;
+      ctx.lineWidth = 2;
+
+      ctx.moveTo(5, canvas.height - 5 - (normalisedVolume * drawHeight));
+
+      let envelope = volume_sweep_change;
+      if (envelope < 0) { //fade down
+        envelope = envelope + 8;
+        var envLength = (envelope / 64 * volume) / 2;
+        ctx.lineTo(5 + Math.min(envLength, secLength) * drawWidth,
+        drawHeight + 5 - (1 - Math.min(secLength / envLength, 1)) * normalisedVolume * drawHeight ); 
+        ctx.lineTo(5 + secLength * drawWidth, canvas.height - 5);
+      }
+      else if (envelope > 0) { //fade up
+        envelope = 8 - envelope;
+        var envLength = (envelope / 64 * (15 - volume)) / 2;
+        ctx.lineTo(5 + Math.min(envLength, secLength) * drawWidth, 
+        (1 - Math.min(secLength / envLength, 1) ) * drawHeight + 5);
+        ctx.lineTo(5 + secLength * drawWidth, (1 - Math.min(secLength / envLength, 1) ) * drawHeight + 5);
+      } else { //no fade
+        ctx.lineTo(5 + secLength * drawWidth, canvas.height - 5 - (normalisedVolume * drawHeight));        
+      }
+      ctx.lineTo(5 + (secLength * drawWidth), canvas.height - 5);
+      if (secLength < 1) {
+        ctx.lineTo(5 + drawWidth, canvas.height - 5);
+      }
+      ctx.stroke();
+    }
+  });
+
+  return (
+    <>
+      <FormRow>
+        <canvas
+          ref={canvasRef}
+          style={{
+            width: "100%",
+            height: "65px",
+            backgroundColor: "#000",
+            borderRadius: 4,
+          }}
+          height={65}
+        />
+      </FormRow>
+    </>
+  );
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](/chrismaltby/gb-studio/blob/develop/.github/COMMIT_MESSAGE_GUIDELINES.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
No visual feedback for sliders

* **What is the new behavior (if this is a feature change)?**
Adds a graph visual for length, initial volume, and sweep / envelope
![image](https://user-images.githubusercontent.com/34431457/119347336-820c9380-bcef-11eb-8817-a4bcf59c55ca.png)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Followed the same implementation as Wave Preview



* **Other information**:
